### PR TITLE
allow for parallel rendering.

### DIFF
--- a/run_eval.py
+++ b/run_eval.py
@@ -35,6 +35,7 @@ def main(
         episodes = 10,
         headless: bool = True,
         scene: int = 1,
+        num_envs: int = 1,
         ):
     # launch omniverse app with arguments (inside function to prevent overriding tyro)
     from isaaclab.app import AppLauncher
@@ -55,7 +56,7 @@ def main(
     env_cfg = parse_env_cfg(
         "DROID",
         device=args_cli.device,
-        num_envs=1,
+        num_envs=num_envs,
         use_fabric=True,
     )
     instruction = None

--- a/src/environments/droid_environment.py
+++ b/src/environments/droid_environment.py
@@ -292,7 +292,7 @@ def arm_joint_pos(
     joint_indices = [
         i for i, name in enumerate(robot.data.joint_names) if name in joint_names
     ]
-    joint_pos = robot.data.joint_pos[0, joint_indices]
+    joint_pos = robot.data.joint_pos[:, joint_indices]
     return joint_pos
 
 
@@ -304,7 +304,7 @@ def gripper_pos(
     joint_indices = [
         i for i, name in enumerate(robot.data.joint_names) if name in joint_names
     ]
-    joint_pos = robot.data.joint_pos[0, joint_indices]
+    joint_pos = robot.data.joint_pos[:, joint_indices]
 
     # rescale
     joint_pos = joint_pos / (np.pi / 4)
@@ -372,7 +372,7 @@ class CurriculumCfg:
 
 @configclass
 class EnvCfg(ManagerBasedRLEnvCfg):
-    scene = SceneCfg(num_envs=1, env_spacing=7.0)
+    scene = SceneCfg(env_spacing=7.0)
 
     observations = ObservationCfg()
     actions = ActionCfg()

--- a/src/inference/droid_jointpos.py
+++ b/src/inference/droid_jointpos.py
@@ -73,8 +73,8 @@ class Client(InferenceClient):
 
     def _extract_observation(self, obs_dict, *, save_to_disk=False):
         # Assign images
-        right_image = obs_dict["policy"]["external_cam"][0].clone().detach().cpu().numpy()
-        wrist_image = obs_dict["policy"]["wrist_cam"][0].clone().detach().cpu().numpy()
+        right_image = obs_dict["policy"]["external_cam"].clone().detach().cpu().numpy()
+        wrist_image = obs_dict["policy"]["wrist_cam"].clone().detach().cpu().numpy()
 
         # Capture proprioceptive state
         robot_state = obs_dict["policy"]


### PR DESCRIPTION
Originally, `obs.reset()` returns:

```
# policy.arm_joint_pos: Tensor, shape=(7,), dtype=torch.float32, device=cuda:0
# policy.gripper_pos: Tensor, shape=(1,), dtype=torch.float32, device=cuda:0
# policy.external_cam: Tensor, shape=(1, 720, 1280, 3), dtype=torch.uint8, device=cuda:0
# policy.wrist_cam: Tensor, shape=(1, 720, 1280, 3), dtype=torch.uint8, device=cuda:0
```

Made changes such that `obs.reset()` returns

```
# policy.arm_joint_pos: Tensor, shape=(B, 7), dtype=torch.float32, device=cuda:0
# policy.gripper_pos: Tensor, shape=(B, 1), dtype=torch.float32, device=cuda:0
# policy.external_cam: Tensor, shape=(B, 720, 1280, 3), dtype=torch.uint8, device=cuda:0
# policy.wrist_cam: Tensor, shape=(B, 720, 1280, 3), dtype=torch.uint8, device=cuda:0
```

This is only a fix on the IsaacLab side, and I did not test whether this works or not with the current `infer` functions. If we do decide to merge this implementation. Please make sure to test the `infer` functions in jax models!!!