### PR TITLE
Register DROID scenes as Gym environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ Finally, run the evaluation script:
 python run_eval.py --episodes [INT] --scene [INT] --headless
 ```
 
+The current scenes are also registered as individual Gym environments:
+
+| Environment ID | Legacy scene id | Prompt |
+| --- | --- | --- |
+| `DROID-CubeInBowl` | `1` | `put the cube in the bowl` |
+| `DROID-CanInMug` | `2` | `put the can in the mug` |
+| `DROID-BananaInBin` | `3` | `put banana in the bin` |
+
+You can run a named environment directly:
+```bash
+python run_eval.py --episodes [INT] --environment DROID-CanInMug --headless
+```
+
 ## Minimal Example
 
 ```python

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ python run_eval.py --episodes [INT] --environment DROID-CubeInBowl --headless
 
 The current scenes are also registered as individual Gym environments:
 
+All `Scene.usd` paths below are relative to `assets/` or `SIM_EVALS_ASSET_ROOT`.
+
 | Environment ID | Expected `Scene.usd` |
 | --- | --- |
 | `DROID-CubeInBowl` | `scene1.usd` |
@@ -88,27 +90,6 @@ The current scenes are also registered as individual Gym environments:
 | `DROID-MILA-Task2` | `MILA/Task2/Scene.usd` |
 | `DROID-FrodoBots-Task1` | `FrodoBots/Task1/Scene.usd` |
 | `DROID-FrodoBots-Task2` | `FrodoBots/Task2/Scene.usd` |
-
-The expected asset layout is:
-```text
-assets/
-  scene1.usd
-  scene2.usd
-  scene3.usd
-  Berkeley/Berkeley_Task1/Scene.usd
-  UPenn/TASK-1-Levine457-FrankaKitchen/Scene.usd
-  UPenn/TASK-2-Levine459-TeaRoom/Scene.usd
-  UPenn/TASK-3-AGH-LivingRoom/Scene.usd
-  UT-Austin/UT-Austin-Task1/Scene.usd
-  UT-Austin/UT-Austin-Task2/Scene.usd
-  UT-Austin/UT-Austin-Task3/Scene.usd
-  Yonsei/Task1_20260424/Scene.usd
-  Yonsei/Task2/Scene.usd
-  MILA/Task1/Scene.usd
-  MILA/Task2/Scene.usd
-  FrodoBots/Task1/Scene.usd
-  FrodoBots/Task2/Scene.usd
-```
 
 You can run a named environment directly:
 ```bash

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ First, make sure you download the simulation assets into the root of this direct
 uvx hf download owhan/DROID-sim-environments --repo-type dataset --local-dir assets
 ```
 
+If the assets live somewhere else, point the evaluator at that directory:
+```bash
+export SIM_EVALS_ASSET_ROOT=/path/to/assets
+```
+
 Then, in a separate terminal, launch the policy server on `localhost:8000`. 
 For example, to launch a pi0-FAST-DROID policy (with joint position control),
 checkout [openpi](https://github.com/Physical-Intelligence/openpi) and use the `polaris` configs 
@@ -65,15 +70,33 @@ python run_eval.py --episodes [INT] --scene [INT] --headless
 
 The current scenes are also registered as individual Gym environments:
 
-| Environment ID | Legacy scene id | Prompt |
+| Environment ID | Scene id | Expected `Scene.usd` |
 | --- | --- | --- |
-| `DROID-CubeInBowl` | `1` | `put the cube in the bowl` |
-| `DROID-CanInMug` | `2` | `put the can in the mug` |
-| `DROID-BananaInBin` | `3` | `put banana in the bin` |
+| `DROID-CubeInBowl` | `1` | `scene1.usd` |
+| `DROID-CanInMug` | `2` | `scene2.usd` |
+| `DROID-BananaInBin` | `3` | `scene3.usd` |
+| `DROID-Berkeley-Task1` | `101` | `Berkeley/Berkeley_Task1/Scene.usd` |
+| `DROID-UPenn-FrankaKitchen` | `201` | `UPenn/TASK-1-Levine457-FrankaKitchen/Scene.usd` |
+| `DROID-UPenn-TeaRoom` | `202` | `UPenn/TASK-2-Levine459-TeaRoom/Scene.usd` |
+| `DROID-UPenn-LivingRoom` | `203` | `UPenn/TASK-3-AGH-LivingRoom/Scene.usd` |
+| `DROID-UTAustin-Task1` | `301` | `UT-Austin/UT-Austin-Task1/Scene.usd` |
+| `DROID-UTAustin-Task2` | `302` | `UT-Austin/UT-Austin-Task2/Scene.usd` |
+| `DROID-UTAustin-Task3` | `303` | `UT-Austin/UT-Austin-Task3/Scene.usd` |
+| `DROID-Yonsei-Task1` | `401` | `Yonsei/Task1_20260424/Scene.usd` |
+| `DROID-Yonsei-Task2` | `402` | `Yonsei/Task2/Scene.usd` |
+| `DROID-MILA-Task1` | `501` | `MILA/Task1/Scene.usd` |
+| `DROID-MILA-Task2` | `502` | `MILA/Task2/Scene.usd` |
+| `DROID-FrodoBots-Task1` | `601` | `FrodoBots/Task1/Scene.usd` |
+| `DROID-FrodoBots-Task2` | `602` | `FrodoBots/Task2/Scene.usd` |
 
 You can run a named environment directly:
 ```bash
 python run_eval.py --episodes [INT] --environment DROID-CanInMug --headless
+```
+
+For LW environments, pass the task prompt explicitly when needed:
+```bash
+python run_eval.py --episodes [INT] --environment DROID-MILA-Task1 --instruction "Pick up the spoon and place it in the sink." --headless
 ```
 
 ## Minimal Example

--- a/README.md
+++ b/README.md
@@ -65,29 +65,50 @@ XLA_PYTHON_CLIENT_MEM_FRACTION=0.5 uv run scripts/serve_policy.py policy:checkpo
 
 Finally, run the evaluation script:
 ```bash
-python run_eval.py --episodes [INT] --scene [INT] --headless
+python run_eval.py --episodes [INT] --environment DROID-CubeInBowl --headless
 ```
 
 The current scenes are also registered as individual Gym environments:
 
-| Environment ID | Scene id | Expected `Scene.usd` |
-| --- | --- | --- |
-| `DROID-CubeInBowl` | `1` | `scene1.usd` |
-| `DROID-CanInMug` | `2` | `scene2.usd` |
-| `DROID-BananaInBin` | `3` | `scene3.usd` |
-| `DROID-Berkeley-Task1` | `101` | `Berkeley/Berkeley_Task1/Scene.usd` |
-| `DROID-UPenn-FrankaKitchen` | `201` | `UPenn/TASK-1-Levine457-FrankaKitchen/Scene.usd` |
-| `DROID-UPenn-TeaRoom` | `202` | `UPenn/TASK-2-Levine459-TeaRoom/Scene.usd` |
-| `DROID-UPenn-LivingRoom` | `203` | `UPenn/TASK-3-AGH-LivingRoom/Scene.usd` |
-| `DROID-UTAustin-Task1` | `301` | `UT-Austin/UT-Austin-Task1/Scene.usd` |
-| `DROID-UTAustin-Task2` | `302` | `UT-Austin/UT-Austin-Task2/Scene.usd` |
-| `DROID-UTAustin-Task3` | `303` | `UT-Austin/UT-Austin-Task3/Scene.usd` |
-| `DROID-Yonsei-Task1` | `401` | `Yonsei/Task1_20260424/Scene.usd` |
-| `DROID-Yonsei-Task2` | `402` | `Yonsei/Task2/Scene.usd` |
-| `DROID-MILA-Task1` | `501` | `MILA/Task1/Scene.usd` |
-| `DROID-MILA-Task2` | `502` | `MILA/Task2/Scene.usd` |
-| `DROID-FrodoBots-Task1` | `601` | `FrodoBots/Task1/Scene.usd` |
-| `DROID-FrodoBots-Task2` | `602` | `FrodoBots/Task2/Scene.usd` |
+| Environment ID | Expected `Scene.usd` |
+| --- | --- |
+| `DROID-CubeInBowl` | `scene1.usd` |
+| `DROID-CanInMug` | `scene2.usd` |
+| `DROID-BananaInBin` | `scene3.usd` |
+| `DROID-Berkeley-Task1` | `Berkeley/Berkeley_Task1/Scene.usd` |
+| `DROID-UPenn-FrankaKitchen` | `UPenn/TASK-1-Levine457-FrankaKitchen/Scene.usd` |
+| `DROID-UPenn-TeaRoom` | `UPenn/TASK-2-Levine459-TeaRoom/Scene.usd` |
+| `DROID-UPenn-LivingRoom` | `UPenn/TASK-3-AGH-LivingRoom/Scene.usd` |
+| `DROID-UTAustin-Task1` | `UT-Austin/UT-Austin-Task1/Scene.usd` |
+| `DROID-UTAustin-Task2` | `UT-Austin/UT-Austin-Task2/Scene.usd` |
+| `DROID-UTAustin-Task3` | `UT-Austin/UT-Austin-Task3/Scene.usd` |
+| `DROID-Yonsei-Task1` | `Yonsei/Task1_20260424/Scene.usd` |
+| `DROID-Yonsei-Task2` | `Yonsei/Task2/Scene.usd` |
+| `DROID-MILA-Task1` | `MILA/Task1/Scene.usd` |
+| `DROID-MILA-Task2` | `MILA/Task2/Scene.usd` |
+| `DROID-FrodoBots-Task1` | `FrodoBots/Task1/Scene.usd` |
+| `DROID-FrodoBots-Task2` | `FrodoBots/Task2/Scene.usd` |
+
+The expected asset layout is:
+```text
+assets/
+  scene1.usd
+  scene2.usd
+  scene3.usd
+  Berkeley/Berkeley_Task1/Scene.usd
+  UPenn/TASK-1-Levine457-FrankaKitchen/Scene.usd
+  UPenn/TASK-2-Levine459-TeaRoom/Scene.usd
+  UPenn/TASK-3-AGH-LivingRoom/Scene.usd
+  UT-Austin/UT-Austin-Task1/Scene.usd
+  UT-Austin/UT-Austin-Task2/Scene.usd
+  UT-Austin/UT-Austin-Task3/Scene.usd
+  Yonsei/Task1_20260424/Scene.usd
+  Yonsei/Task2/Scene.usd
+  MILA/Task1/Scene.usd
+  MILA/Task2/Scene.usd
+  FrodoBots/Task1/Scene.usd
+  FrodoBots/Task2/Scene.usd
+```
 
 You can run a named environment directly:
 ```bash
@@ -102,8 +123,7 @@ python run_eval.py --episodes [INT] --environment DROID-MILA-Task1 --instruction
 ## Minimal Example
 
 ```python
-env_cfg.set_scene(scene) # pass scene integer
-env = gym.make("DROID", cfg=env_cfg)
+env = gym.make("DROID-CubeInBowl", cfg=env_cfg)
 
 obs, _ = env.reset()
 obs, _ = env.reset() # need second render cycle to get correctly loaded materials

--- a/run_eval.py
+++ b/run_eval.py
@@ -17,6 +17,7 @@ Finally, run the evaluation script:
 
 python run_eval.py --episodes 10 --headless
 python run_eval.py --episodes 10 --environment DROID-CanInMug --headless
+python run_eval.py --episodes 10 --environment DROID-MILA-Task1 --instruction "Pick up the spoon and place it in the sink." --headless
 """
 
 import tyro
@@ -37,6 +38,7 @@ def main(
         headless: bool = True,
         scene: int = 1,
         environment: str | None = None,
+        instruction: str | None = None,
         ):
     # launch omniverse app with arguments (inside function to prevent overriding tyro)
     from isaaclab.app import AppLauncher
@@ -72,7 +74,7 @@ def main(
     )
 
     env_cfg.set_scene(scene_spec.scene_id)
-    instruction = getattr(env_cfg, "language_instruction", scene_spec.instruction)
+    policy_instruction = instruction or getattr(env_cfg, "language_instruction", scene_spec.instruction)
     env = gym.make(env_id, cfg=env_cfg)
 
     obs, _ = env.reset()
@@ -88,7 +90,7 @@ def main(
     with torch.no_grad():
         for ep in range(episodes):
             for _ in tqdm(range(max_steps), desc=f"Episode {ep+1}/{episodes}"):
-                ret = client.infer(obs, instruction)
+                ret = client.infer(obs, policy_instruction)
                 if not headless:
                     cv2.imshow("Right Camera", cv2.cvtColor(ret["viz"], cv2.COLOR_RGB2BGR))
                     cv2.waitKey(1)

--- a/run_eval.py
+++ b/run_eval.py
@@ -36,8 +36,7 @@ from sim_evals.inference.droid_jointpos import Client as DroidJointPosClient
 def main(
         episodes:int = 10,
         headless: bool = True,
-        scene: int = 1,
-        environment: str | None = None,
+        environment: str = "DROID-CubeInBowl",
         instruction: str | None = None,
         ):
     # launch omniverse app with arguments (inside function to prevent overriding tyro)
@@ -55,27 +54,18 @@ def main(
     from sim_evals.environments.droid_environment import get_scene_spec
     from isaaclab_tasks.utils import parse_env_cfg
 
-    if environment is None:
-        scene_spec = get_scene_spec(scene)
-        env_id = scene_spec.env_id
-    elif environment == "DROID":
-        scene_spec = get_scene_spec(scene)
-        env_id = environment
-    else:
-        scene_spec = get_scene_spec(environment)
-        env_id = scene_spec.env_id
+    scene_spec = get_scene_spec(environment)
 
     # Initialize the env
     env_cfg = parse_env_cfg(
-        env_id,
+        environment,
         device=args_cli.device,
         num_envs=1,
         use_fabric=True,
     )
 
-    env_cfg.set_scene(scene_spec.scene_id)
     policy_instruction = instruction or getattr(env_cfg, "language_instruction", scene_spec.instruction)
-    env = gym.make(env_id, cfg=env_cfg)
+    env = gym.make(environment, cfg=env_cfg)
 
     obs, _ = env.reset()
     obs, _ = env.reset() # need second render cycle to get correctly loaded materials

--- a/run_eval.py
+++ b/run_eval.py
@@ -16,6 +16,7 @@ XLA_PYTHON_CLIENT_MEM_FRACTION=0.5 uv run scripts/serve_policy.py policy:checkpo
 Finally, run the evaluation script:
 
 python run_eval.py --episodes 10 --headless
+python run_eval.py --episodes 10 --environment DROID-CanInMug --headless
 """
 
 import tyro
@@ -35,6 +36,7 @@ def main(
         episodes:int = 10,
         headless: bool = True,
         scene: int = 1,
+        environment: str | None = None,
         ):
     # launch omniverse app with arguments (inside function to prevent overriding tyro)
     from isaaclab.app import AppLauncher
@@ -48,29 +50,30 @@ def main(
 
     # All IsaacLab dependent modules should be imported after the app is launched
     import sim_evals.environments # noqa: F401
+    from sim_evals.environments.droid_environment import get_scene_spec
     from isaaclab_tasks.utils import parse_env_cfg
 
+    if environment is None:
+        scene_spec = get_scene_spec(scene)
+        env_id = scene_spec.env_id
+    elif environment == "DROID":
+        scene_spec = get_scene_spec(scene)
+        env_id = environment
+    else:
+        scene_spec = get_scene_spec(environment)
+        env_id = scene_spec.env_id
 
     # Initialize the env
     env_cfg = parse_env_cfg(
-        "DROID",
+        env_id,
         device=args_cli.device,
         num_envs=1,
         use_fabric=True,
     )
-    instruction = None
-    match scene:
-        case 1:
-            instruction = "put the cube in the bowl"
-        case 2:
-            instruction = "put the can in the mug"
-        case 3:
-            instruction = "put banana in the bin"
-        case _:
-            raise ValueError(f"Scene {scene} not supported")
-        
-    env_cfg.set_scene(scene)
-    env = gym.make("DROID", cfg=env_cfg)
+
+    env_cfg.set_scene(scene_spec.scene_id)
+    instruction = getattr(env_cfg, "language_instruction", scene_spec.instruction)
+    env = gym.make(env_id, cfg=env_cfg)
 
     obs, _ = env.reset()
     obs, _ = env.reset() # need second render cycle to get correctly loaded materials

--- a/src/sim_evals/environments/__init__.py
+++ b/src/sim_evals/environments/__init__.py
@@ -1,12 +1,33 @@
 import gymnasium as gym
-from .droid_environment import EnvCfg as DroidEnvCfg
+from .droid_environment import (
+    BananaInBinEnvCfg,
+    CanInMugEnvCfg,
+    CubeInBowlEnvCfg,
+    EnvCfg as DroidEnvCfg,
+)
 from isaaclab.envs import ManagerBasedRLEnv
 
-gym.register(
-    id="DROID",
-    entry_point=ManagerBasedRLEnv,
-    kwargs={
-        "env_cfg_entry_point": DroidEnvCfg,
-    },
-    disable_env_checker=True,
-)
+_DROID_ENV_CFGS = {
+    "DROID": DroidEnvCfg,
+    "DROID-CubeInBowl": CubeInBowlEnvCfg,
+    "DROID-CanInMug": CanInMugEnvCfg,
+    "DROID-BananaInBin": BananaInBinEnvCfg,
+}
+
+
+def _register_droid_env(env_id: str, env_cfg_entry_point: type[DroidEnvCfg]) -> None:
+    if env_id in gym.envs.registry:
+        return
+
+    gym.register(
+        id=env_id,
+        entry_point=ManagerBasedRLEnv,
+        kwargs={
+            "env_cfg_entry_point": env_cfg_entry_point,
+        },
+        disable_env_checker=True,
+    )
+
+
+for _env_id, _env_cfg_entry_point in _DROID_ENV_CFGS.items():
+    _register_droid_env(_env_id, _env_cfg_entry_point)

--- a/src/sim_evals/environments/__init__.py
+++ b/src/sim_evals/environments/__init__.py
@@ -1,15 +1,121 @@
 import gymnasium as gym
-from .droid_environment import (
-    DROID_SCENES,
-    EnvCfg as DroidEnvCfg,
-    make_env_cfg_class,
-)
-from isaaclab.envs import ManagerBasedRLEnv
 
-_DROID_ENV_CFGS = {"DROID": DroidEnvCfg}
-_DROID_ENV_CFGS.update(
-    {scene_spec.env_id: make_env_cfg_class(scene_spec.env_id) for scene_spec in DROID_SCENES.values()}
-)
+from isaaclab.envs import ManagerBasedRLEnv
+from isaaclab.utils import configclass
+
+from .droid_environment import EnvCfg as DroidEnvCfg
+
+
+@configclass
+class DroidCubeInBowlEnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-CubeInBowl")
+
+
+@configclass
+class DroidCanInMugEnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-CanInMug")
+
+
+@configclass
+class DroidBananaInBinEnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-BananaInBin")
+
+
+@configclass
+class DroidBerkeleyTask1EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-Berkeley-Task1")
+
+
+@configclass
+class DroidUPennFrankaKitchenEnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-UPenn-FrankaKitchen")
+
+
+@configclass
+class DroidUPennTeaRoomEnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-UPenn-TeaRoom")
+
+
+@configclass
+class DroidUPennLivingRoomEnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-UPenn-LivingRoom")
+
+
+@configclass
+class DroidUTAustinTask1EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-UTAustin-Task1")
+
+
+@configclass
+class DroidUTAustinTask2EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-UTAustin-Task2")
+
+
+@configclass
+class DroidUTAustinTask3EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-UTAustin-Task3")
+
+
+@configclass
+class DroidYonseiTask1EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-Yonsei-Task1")
+
+
+@configclass
+class DroidYonseiTask2EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-Yonsei-Task2")
+
+
+@configclass
+class DroidMILATask1EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-MILA-Task1")
+
+
+@configclass
+class DroidMILATask2EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-MILA-Task2")
+
+
+@configclass
+class DroidFrodoBotsTask1EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-FrodoBots-Task1")
+
+
+@configclass
+class DroidFrodoBotsTask2EnvCfg(DroidEnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene("DROID-FrodoBots-Task2")
 
 
 def _register_droid_env(env_id: str, env_cfg_entry_point: type[DroidEnvCfg]) -> None:
@@ -26,5 +132,19 @@ def _register_droid_env(env_id: str, env_cfg_entry_point: type[DroidEnvCfg]) -> 
     )
 
 
-for _env_id, _env_cfg_entry_point in _DROID_ENV_CFGS.items():
-    _register_droid_env(_env_id, _env_cfg_entry_point)
+_register_droid_env("DROID-CubeInBowl", DroidCubeInBowlEnvCfg)
+_register_droid_env("DROID-CanInMug", DroidCanInMugEnvCfg)
+_register_droid_env("DROID-BananaInBin", DroidBananaInBinEnvCfg)
+_register_droid_env("DROID-Berkeley-Task1", DroidBerkeleyTask1EnvCfg)
+_register_droid_env("DROID-UPenn-FrankaKitchen", DroidUPennFrankaKitchenEnvCfg)
+_register_droid_env("DROID-UPenn-TeaRoom", DroidUPennTeaRoomEnvCfg)
+_register_droid_env("DROID-UPenn-LivingRoom", DroidUPennLivingRoomEnvCfg)
+_register_droid_env("DROID-UTAustin-Task1", DroidUTAustinTask1EnvCfg)
+_register_droid_env("DROID-UTAustin-Task2", DroidUTAustinTask2EnvCfg)
+_register_droid_env("DROID-UTAustin-Task3", DroidUTAustinTask3EnvCfg)
+_register_droid_env("DROID-Yonsei-Task1", DroidYonseiTask1EnvCfg)
+_register_droid_env("DROID-Yonsei-Task2", DroidYonseiTask2EnvCfg)
+_register_droid_env("DROID-MILA-Task1", DroidMILATask1EnvCfg)
+_register_droid_env("DROID-MILA-Task2", DroidMILATask2EnvCfg)
+_register_droid_env("DROID-FrodoBots-Task1", DroidFrodoBotsTask1EnvCfg)
+_register_droid_env("DROID-FrodoBots-Task2", DroidFrodoBotsTask2EnvCfg)

--- a/src/sim_evals/environments/__init__.py
+++ b/src/sim_evals/environments/__init__.py
@@ -1,18 +1,15 @@
 import gymnasium as gym
 from .droid_environment import (
-    BananaInBinEnvCfg,
-    CanInMugEnvCfg,
-    CubeInBowlEnvCfg,
+    DROID_SCENES,
     EnvCfg as DroidEnvCfg,
+    make_env_cfg_class,
 )
 from isaaclab.envs import ManagerBasedRLEnv
 
-_DROID_ENV_CFGS = {
-    "DROID": DroidEnvCfg,
-    "DROID-CubeInBowl": CubeInBowlEnvCfg,
-    "DROID-CanInMug": CanInMugEnvCfg,
-    "DROID-BananaInBin": BananaInBinEnvCfg,
-}
+_DROID_ENV_CFGS = {"DROID": DroidEnvCfg}
+_DROID_ENV_CFGS.update(
+    {scene_spec.env_id: make_env_cfg_class(scene_spec.env_id) for scene_spec in DROID_SCENES.values()}
+)
 
 
 def _register_droid_env(env_id: str, env_cfg_entry_point: type[DroidEnvCfg]) -> None:

--- a/src/sim_evals/environments/droid_environment.py
+++ b/src/sim_evals/environments/droid_environment.py
@@ -3,7 +3,7 @@ import isaaclab.sim as sim_utils
 import isaaclab.envs.mdp as mdp
 import numpy as np
 
-from typing import List
+from typing import NamedTuple
 from pathlib import Path
 from pxr import Usd, UsdPhysics
 
@@ -25,6 +25,51 @@ from isaaclab.sensors import CameraCfg
 from .nvidia_droid import NVIDIA_DROID
 
 DATA_PATH = Path(__file__).parent / "../../../assets/"
+
+
+class DroidSceneSpec(NamedTuple):
+    env_id: str
+    scene_id: int
+    instruction: str
+
+
+DROID_SCENES = {
+    1: DroidSceneSpec(
+        env_id="DROID-CubeInBowl",
+        scene_id=1,
+        instruction="put the cube in the bowl",
+    ),
+    2: DroidSceneSpec(
+        env_id="DROID-CanInMug",
+        scene_id=2,
+        instruction="put the can in the mug",
+    ),
+    3: DroidSceneSpec(
+        env_id="DROID-BananaInBin",
+        scene_id=3,
+        instruction="put banana in the bin",
+    ),
+}
+
+ENV_ID_TO_SCENE = {spec.env_id: spec for spec in DROID_SCENES.values()}
+
+
+def get_scene_spec(scene: int | str) -> DroidSceneSpec:
+    if isinstance(scene, str):
+        if scene.isdigit():
+            scene = int(scene)
+        elif scene in ENV_ID_TO_SCENE:
+            return ENV_ID_TO_SCENE[scene]
+        else:
+            valid = ", ".join(spec.env_id for spec in DROID_SCENES.values())
+            raise ValueError(f"Unknown DROID scene {scene!r}. Valid env ids: {valid}")
+
+    try:
+        return DROID_SCENES[int(scene)]
+    except (KeyError, ValueError) as exc:
+        valid = ", ".join(str(scene_id) for scene_id in DROID_SCENES)
+        raise ValueError(f"Unknown DROID scene {scene!r}. Valid scene ids: {valid}") from exc
+
 
 @configclass
 class SceneCfg(InteractiveSceneCfg):
@@ -86,8 +131,12 @@ class SceneCfg(InteractiveSceneCfg):
         ),
     )
 
-    def dynamic_scene(self, scene_name: str):
-        environment_path = DATA_PATH / f"scene{scene_name}.usd"
+    def dynamic_scene(self, scene_name: int | str) -> dict:
+        scene_spec = get_scene_spec(scene_name)
+        environment_path = DATA_PATH / f"scene{scene_spec.scene_id}.usd"
+        if not environment_path.exists():
+            raise FileNotFoundError(f"Could not find DROID scene asset: {environment_path}")
+
         scene = AssetBaseCfg(
                 prim_path="{ENV_REGEX_NS}/scene",
                 spawn = sim_utils.UsdFileCfg(
@@ -95,10 +144,15 @@ class SceneCfg(InteractiveSceneCfg):
                     ),
                 )
         self.scene = scene
+        scene_object_names = []
+        scene_objects = {}
 
         stage = Usd.Stage.Open(
             str(environment_path)
         )
+        if stage is None:
+            raise RuntimeError(f"Failed to open DROID scene asset: {environment_path}")
+
         scene_prim = stage.GetPrimAtPath("/World")
         children = scene_prim.GetChildren()
 
@@ -108,7 +162,7 @@ class SceneCfg(InteractiveSceneCfg):
                 continue
 
             name = child.GetName()
-            print(f"Found rigid body: {name}")
+            scene_object_names.append(name)
             pos = child.GetAttribute("xformOp:translate").Get()
             rot = child.GetAttribute("xformOp:orient").Get()
             rot = (rot.GetReal(), rot.GetImaginary()[0], rot.GetImaginary()[1], rot.GetImaginary()[2])
@@ -121,6 +175,16 @@ class SceneCfg(InteractiveSceneCfg):
                         ),
                     )
             setattr(self, name, asset)
+            scene_objects[name] = asset
+
+        return {
+            "scene_id": scene_spec.scene_id,
+            "scene_env_id": scene_spec.env_id,
+            "scene_instruction": scene_spec.instruction,
+            "scene_asset_path": str(environment_path),
+            "scene_object_names": scene_object_names,
+            "scene_objects": scene_objects,
+        }
 
 
 class BinaryJointPositionZeroToOneAction(BinaryJointPositionAction):
@@ -305,7 +369,35 @@ class EnvCfg(ManagerBasedRLEnvCfg):
         self.rerender_on_reset = True
 
     
-    def set_scene(self, scene_name: str):
-        self.scene.dynamic_scene(scene_name)
+    def set_scene(self, scene_name: int | str):
+        scene_spec = get_scene_spec(scene_name)
+        self.scene_id = scene_spec.scene_id
+        self.scene_env_id = scene_spec.env_id
+        self.language_instruction = scene_spec.instruction
+        scene_metadata = self.scene.dynamic_scene(scene_spec.scene_id)
+        self.scene_asset_path = scene_metadata["scene_asset_path"]
+        self.scene_object_names = scene_metadata["scene_object_names"]
+        self.scene_objects = scene_metadata["scene_objects"]
+
+
+@configclass
+class CubeInBowlEnvCfg(EnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene(1)
+
+
+@configclass
+class CanInMugEnvCfg(EnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene(2)
+
+
+@configclass
+class BananaInBinEnvCfg(EnvCfg):
+    def __post_init__(self):
+        super().__post_init__()
+        self.set_scene(3)
 
 

--- a/src/sim_evals/environments/droid_environment.py
+++ b/src/sim_evals/environments/droid_environment.py
@@ -2,6 +2,7 @@ import torch
 import isaaclab.sim as sim_utils
 import isaaclab.envs.mdp as mdp
 import numpy as np
+import os
 
 from typing import NamedTuple
 from pathlib import Path
@@ -24,34 +25,141 @@ from isaaclab.sensors import CameraCfg
 
 from .nvidia_droid import NVIDIA_DROID
 
-DATA_PATH = Path(__file__).parent / "../../../assets/"
+ASSET_ROOT_ENV_VAR = "SIM_EVALS_ASSET_ROOT"
+DEFAULT_DATA_PATH = Path(__file__).resolve().parents[3] / "assets"
 
 
 class DroidSceneSpec(NamedTuple):
     env_id: str
     scene_id: int
     instruction: str
+    asset_paths: tuple[str, ...]
+
+
+def _spec(env_id: str, scene_id: int, instruction: str, *asset_paths: str) -> DroidSceneSpec:
+    return DroidSceneSpec(
+        env_id=env_id,
+        scene_id=scene_id,
+        instruction=instruction,
+        asset_paths=asset_paths,
+    )
 
 
 DROID_SCENES = {
-    1: DroidSceneSpec(
-        env_id="DROID-CubeInBowl",
-        scene_id=1,
-        instruction="put the cube in the bowl",
+    1: _spec("DROID-CubeInBowl", 1, "put the cube in the bowl", "scene1.usd"),
+    2: _spec("DROID-CanInMug", 2, "put the can in the mug", "scene2.usd"),
+    3: _spec("DROID-BananaInBin", 3, "put banana in the bin", "scene3.usd"),
+    101: _spec(
+        "DROID-Berkeley-Task1",
+        101,
+        "complete the Berkeley task 1",
+        "Berkeley/Berkeley_Task1/Scene.usd",
+        "Berkeley_Task1/Scene.usd",
     ),
-    2: DroidSceneSpec(
-        env_id="DROID-CanInMug",
-        scene_id=2,
-        instruction="put the can in the mug",
+    201: _spec(
+        "DROID-UPenn-FrankaKitchen",
+        201,
+        "complete the Franka kitchen task",
+        "UPenn/TASK-1-Levine457-FrankaKitchen/Scene.usd",
+        "TASK-1-Levine457-FrankaKitchen/Scene.usd",
     ),
-    3: DroidSceneSpec(
-        env_id="DROID-BananaInBin",
-        scene_id=3,
-        instruction="put banana in the bin",
+    202: _spec(
+        "DROID-UPenn-TeaRoom",
+        202,
+        "complete the tea room task",
+        "UPenn/TASK-2-Levine459-TeaRoom/Scene.usd",
+        "TASK-2-Levine459-TeaRoom/Scene.usd",
+    ),
+    203: _spec(
+        "DROID-UPenn-LivingRoom",
+        203,
+        "complete the living room task",
+        "UPenn/TASK-3-AGH-LivingRoom/Scene.usd",
+        "TASK-3-AGH-LivingRoom/Scene.usd",
+    ),
+    301: _spec(
+        "DROID-UTAustin-Task1",
+        301,
+        "complete the UT Austin task 1",
+        "UT-Austin/UT-Austin-Task1/Scene.usd",
+        "UT-Austin-Task1/Scene.usd",
+    ),
+    302: _spec(
+        "DROID-UTAustin-Task2",
+        302,
+        "complete the UT Austin task 2",
+        "UT-Austin/UT-Austin-Task2/Scene.usd",
+        "UT-Austin-Task2/Scene.usd",
+    ),
+    303: _spec(
+        "DROID-UTAustin-Task3",
+        303,
+        "complete the UT Austin task 3",
+        "UT-Austin/UT-Austin-Task3/Scene.usd",
+        "UT-Austin-Task3/Scene.usd",
+    ),
+    401: _spec(
+        "DROID-Yonsei-Task1",
+        401,
+        "complete the Yonsei task 1",
+        "Yonsei/Task1_20260424/Scene.usd",
+        "Task1_20260424/Scene.usd",
+    ),
+    402: _spec(
+        "DROID-Yonsei-Task2",
+        402,
+        "complete the Yonsei task 2",
+        "Yonsei/Task2/Scene.usd",
+        "Task2/Scene.usd",
+    ),
+    501: _spec(
+        "DROID-MILA-Task1",
+        501,
+        "complete the MILA task 1",
+        "MILA/Task1/Scene.usd",
+        "Task1/Scene.usd",
+    ),
+    502: _spec(
+        "DROID-MILA-Task2",
+        502,
+        "complete the MILA task 2",
+        "MILA/Task2/Scene.usd",
+        "Task2/Scene.usd",
+    ),
+    601: _spec(
+        "DROID-FrodoBots-Task1",
+        601,
+        "complete the FrodoBots task 1",
+        "FrodoBots/Task1/Scene.usd",
+        "Task1/Scene.usd",
+    ),
+    602: _spec(
+        "DROID-FrodoBots-Task2",
+        602,
+        "complete the FrodoBots task 2",
+        "FrodoBots/Task2/Scene.usd",
+        "Task2/Scene.usd",
     ),
 }
 
 ENV_ID_TO_SCENE = {spec.env_id: spec for spec in DROID_SCENES.values()}
+
+
+def get_data_path() -> Path:
+    return Path(os.environ.get(ASSET_ROOT_ENV_VAR, DEFAULT_DATA_PATH)).expanduser().resolve()
+
+
+def resolve_scene_asset_path(scene_spec: DroidSceneSpec) -> Path:
+    candidates = [get_data_path() / asset_path for asset_path in scene_spec.asset_paths]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    candidate_text = "\n  - ".join(str(path) for path in candidates)
+    raise FileNotFoundError(
+        f"Could not find asset for {scene_spec.env_id}. Checked:\n  - {candidate_text}\n"
+        f"Set {ASSET_ROOT_ENV_VAR} to the directory containing the downloaded assets."
+    )
 
 
 def get_scene_spec(scene: int | str) -> DroidSceneSpec:
@@ -69,6 +177,55 @@ def get_scene_spec(scene: int | str) -> DroidSceneSpec:
     except (KeyError, ValueError) as exc:
         valid = ", ".join(str(scene_id) for scene_id in DROID_SCENES)
         raise ValueError(f"Unknown DROID scene {scene!r}. Valid scene ids: {valid}") from exc
+
+
+def _relative_scene_prim_path(stage: Usd.Stage, prim: Usd.Prim) -> str:
+    prim_path = str(prim.GetPath())
+    default_prim = stage.GetDefaultPrim()
+    root_candidates = []
+    if default_prim and default_prim.IsValid():
+        root_candidates.append(str(default_prim.GetPath()))
+    root_candidates.append("/World")
+
+    for root_path in root_candidates:
+        if prim_path == root_path:
+            return ""
+        if prim_path.startswith(f"{root_path}/"):
+            return prim_path[len(root_path):]
+
+    return prim_path
+
+
+def _scene_attr_name(relative_prim_path: str, used_names: set[str]) -> str:
+    name = relative_prim_path.strip("/").replace("/", "_") or "object"
+    name = "".join(char if char.isalnum() or char == "_" else "_" for char in name)
+    if name[0].isdigit():
+        name = f"object_{name}"
+
+    base_name = name
+    suffix = 2
+    while name in used_names:
+        name = f"{base_name}_{suffix}"
+        suffix += 1
+    used_names.add(name)
+    return name
+
+
+def _rigid_body_initial_state(prim: Usd.Prim) -> RigidObjectCfg.InitialStateCfg:
+    pos_attr = prim.GetAttribute("xformOp:translate")
+    rot_attr = prim.GetAttribute("xformOp:orient")
+    pos = pos_attr.Get() if pos_attr and pos_attr.HasAuthoredValueOpinion() else (0.0, 0.0, 0.0)
+    rot_value = rot_attr.Get() if rot_attr and rot_attr.HasAuthoredValueOpinion() else None
+    if rot_value is None:
+        rot = (1.0, 0.0, 0.0, 0.0)
+    else:
+        rot = (
+            rot_value.GetReal(),
+            rot_value.GetImaginary()[0],
+            rot_value.GetImaginary()[1],
+            rot_value.GetImaginary()[2],
+        )
+    return RigidObjectCfg.InitialStateCfg(pos=pos, rot=rot)
 
 
 @configclass
@@ -133,9 +290,7 @@ class SceneCfg(InteractiveSceneCfg):
 
     def dynamic_scene(self, scene_name: int | str) -> dict:
         scene_spec = get_scene_spec(scene_name)
-        environment_path = DATA_PATH / f"scene{scene_spec.scene_id}.usd"
-        if not environment_path.exists():
-            raise FileNotFoundError(f"Could not find DROID scene asset: {environment_path}")
+        environment_path = resolve_scene_asset_path(scene_spec)
 
         scene = AssetBaseCfg(
                 prim_path="{ENV_REGEX_NS}/scene",
@@ -147,32 +302,37 @@ class SceneCfg(InteractiveSceneCfg):
         scene_object_names = []
         scene_objects = {}
 
+        if scene_spec.scene_id > 3:
+            return {
+                "scene_id": scene_spec.scene_id,
+                "scene_env_id": scene_spec.env_id,
+                "scene_instruction": scene_spec.instruction,
+                "scene_asset_path": str(environment_path),
+                "scene_object_names": scene_object_names,
+                "scene_objects": scene_objects,
+            }
+
         stage = Usd.Stage.Open(
             str(environment_path)
         )
         if stage is None:
             raise RuntimeError(f"Failed to open DROID scene asset: {environment_path}")
 
-        scene_prim = stage.GetPrimAtPath("/World")
-        children = scene_prim.GetChildren()
-
-        for child in children:
-            # if rigid body
+        used_object_names = set()
+        for child in stage.Traverse():
             if not UsdPhysics.RigidBodyAPI(child):
                 continue
 
-            name = child.GetName()
+            relative_prim_path = _relative_scene_prim_path(stage, child)
+            if not relative_prim_path:
+                continue
+
+            name = _scene_attr_name(relative_prim_path, used_object_names)
             scene_object_names.append(name)
-            pos = child.GetAttribute("xformOp:translate").Get()
-            rot = child.GetAttribute("xformOp:orient").Get()
-            rot = (rot.GetReal(), rot.GetImaginary()[0], rot.GetImaginary()[1], rot.GetImaginary()[2])
             asset = RigidObjectCfg(
-                        prim_path=f"{{ENV_REGEX_NS}}/scene/{name}",
+                        prim_path=f"{{ENV_REGEX_NS}}/scene{relative_prim_path}",
                         spawn=None,
-                        init_state=RigidObjectCfg.InitialStateCfg(
-                            pos=pos,
-                            rot=rot,
-                        ),
+                        init_state=_rigid_body_initial_state(child),
                     )
             setattr(self, name, asset)
             scene_objects[name] = asset
@@ -399,5 +559,20 @@ class BananaInBinEnvCfg(EnvCfg):
     def __post_init__(self):
         super().__post_init__()
         self.set_scene(3)
+
+
+def make_env_cfg_class(scene_name: int | str) -> type[EnvCfg]:
+    scene_spec = get_scene_spec(scene_name)
+
+    @configclass
+    class DroidSceneEnvCfg(EnvCfg):
+        def __post_init__(self):
+            super().__post_init__()
+            self.set_scene(scene_spec.env_id)
+
+    class_name = f"{scene_spec.env_id.replace('-', '')}EnvCfg"
+    DroidSceneEnvCfg.__name__ = class_name
+    DroidSceneEnvCfg.__qualname__ = class_name
+    return DroidSceneEnvCfg
 
 

--- a/src/sim_evals/environments/droid_environment.py
+++ b/src/sim_evals/environments/droid_environment.py
@@ -6,13 +6,12 @@ import os
 
 from typing import NamedTuple
 from pathlib import Path
-from pxr import Usd, UsdPhysics
 
 from isaaclab.envs.mdp.actions.actions_cfg import BinaryJointPositionActionCfg
 from isaaclab.envs.mdp.actions.binary_joint_actions import BinaryJointPositionAction
 from isaaclab.envs.mdp.actions.joint_actions import JointAction
 from isaaclab.utils import configclass, noise
-from isaaclab.assets import AssetBaseCfg, ArticulationCfg, RigidObjectCfg
+from isaaclab.assets import AssetBaseCfg, ArticulationCfg
 from isaaclab.actuators import ImplicitActuatorCfg
 from isaaclab.managers import SceneEntityCfg
 from isaaclab.scene import InteractiveSceneCfg
@@ -30,119 +29,67 @@ DEFAULT_DATA_PATH = Path(__file__).resolve().parents[3] / "assets"
 
 
 class DroidSceneSpec(NamedTuple):
-    env_id: str
-    scene_id: int
     instruction: str
     asset_paths: tuple[str, ...]
 
 
-def _spec(env_id: str, scene_id: int, instruction: str, *asset_paths: str) -> DroidSceneSpec:
-    return DroidSceneSpec(
-        env_id=env_id,
-        scene_id=scene_id,
-        instruction=instruction,
-        asset_paths=asset_paths,
-    )
-
-
 DROID_SCENES = {
-    1: _spec("DROID-CubeInBowl", 1, "put the cube in the bowl", "scene1.usd"),
-    2: _spec("DROID-CanInMug", 2, "put the can in the mug", "scene2.usd"),
-    3: _spec("DROID-BananaInBin", 3, "put banana in the bin", "scene3.usd"),
-    101: _spec(
-        "DROID-Berkeley-Task1",
-        101,
+    "DROID-CubeInBowl": DroidSceneSpec("put the cube in the bowl", ("scene1.usd",)),
+    "DROID-CanInMug": DroidSceneSpec("put the can in the mug", ("scene2.usd",)),
+    "DROID-BananaInBin": DroidSceneSpec("put banana in the bin", ("scene3.usd",)),
+    "DROID-Berkeley-Task1": DroidSceneSpec(
         "complete the Berkeley task 1",
-        "Berkeley/Berkeley_Task1/Scene.usd",
-        "Berkeley_Task1/Scene.usd",
+        ("Berkeley/Berkeley_Task1/Scene.usd", "Berkeley_Task1/Scene.usd"),
     ),
-    201: _spec(
-        "DROID-UPenn-FrankaKitchen",
-        201,
+    "DROID-UPenn-FrankaKitchen": DroidSceneSpec(
         "complete the Franka kitchen task",
-        "UPenn/TASK-1-Levine457-FrankaKitchen/Scene.usd",
-        "TASK-1-Levine457-FrankaKitchen/Scene.usd",
+        ("UPenn/TASK-1-Levine457-FrankaKitchen/Scene.usd", "TASK-1-Levine457-FrankaKitchen/Scene.usd"),
     ),
-    202: _spec(
-        "DROID-UPenn-TeaRoom",
-        202,
+    "DROID-UPenn-TeaRoom": DroidSceneSpec(
         "complete the tea room task",
-        "UPenn/TASK-2-Levine459-TeaRoom/Scene.usd",
-        "TASK-2-Levine459-TeaRoom/Scene.usd",
+        ("UPenn/TASK-2-Levine459-TeaRoom/Scene.usd", "TASK-2-Levine459-TeaRoom/Scene.usd"),
     ),
-    203: _spec(
-        "DROID-UPenn-LivingRoom",
-        203,
+    "DROID-UPenn-LivingRoom": DroidSceneSpec(
         "complete the living room task",
-        "UPenn/TASK-3-AGH-LivingRoom/Scene.usd",
-        "TASK-3-AGH-LivingRoom/Scene.usd",
+        ("UPenn/TASK-3-AGH-LivingRoom/Scene.usd", "TASK-3-AGH-LivingRoom/Scene.usd"),
     ),
-    301: _spec(
-        "DROID-UTAustin-Task1",
-        301,
+    "DROID-UTAustin-Task1": DroidSceneSpec(
         "complete the UT Austin task 1",
-        "UT-Austin/UT-Austin-Task1/Scene.usd",
-        "UT-Austin-Task1/Scene.usd",
+        ("UT-Austin/UT-Austin-Task1/Scene.usd", "UT-Austin-Task1/Scene.usd"),
     ),
-    302: _spec(
-        "DROID-UTAustin-Task2",
-        302,
+    "DROID-UTAustin-Task2": DroidSceneSpec(
         "complete the UT Austin task 2",
-        "UT-Austin/UT-Austin-Task2/Scene.usd",
-        "UT-Austin-Task2/Scene.usd",
+        ("UT-Austin/UT-Austin-Task2/Scene.usd", "UT-Austin-Task2/Scene.usd"),
     ),
-    303: _spec(
-        "DROID-UTAustin-Task3",
-        303,
+    "DROID-UTAustin-Task3": DroidSceneSpec(
         "complete the UT Austin task 3",
-        "UT-Austin/UT-Austin-Task3/Scene.usd",
-        "UT-Austin-Task3/Scene.usd",
+        ("UT-Austin/UT-Austin-Task3/Scene.usd", "UT-Austin-Task3/Scene.usd"),
     ),
-    401: _spec(
-        "DROID-Yonsei-Task1",
-        401,
+    "DROID-Yonsei-Task1": DroidSceneSpec(
         "complete the Yonsei task 1",
-        "Yonsei/Task1_20260424/Scene.usd",
-        "Task1_20260424/Scene.usd",
+        ("Yonsei/Task1_20260424/Scene.usd", "Task1_20260424/Scene.usd"),
     ),
-    402: _spec(
-        "DROID-Yonsei-Task2",
-        402,
+    "DROID-Yonsei-Task2": DroidSceneSpec(
         "complete the Yonsei task 2",
-        "Yonsei/Task2/Scene.usd",
-        "Task2/Scene.usd",
+        ("Yonsei/Task2/Scene.usd", "Task2/Scene.usd"),
     ),
-    501: _spec(
-        "DROID-MILA-Task1",
-        501,
+    "DROID-MILA-Task1": DroidSceneSpec(
         "complete the MILA task 1",
-        "MILA/Task1/Scene.usd",
-        "Task1/Scene.usd",
+        ("MILA/Task1/Scene.usd", "Task1/Scene.usd"),
     ),
-    502: _spec(
-        "DROID-MILA-Task2",
-        502,
+    "DROID-MILA-Task2": DroidSceneSpec(
         "complete the MILA task 2",
-        "MILA/Task2/Scene.usd",
-        "Task2/Scene.usd",
+        ("MILA/Task2/Scene.usd", "Task2/Scene.usd"),
     ),
-    601: _spec(
-        "DROID-FrodoBots-Task1",
-        601,
+    "DROID-FrodoBots-Task1": DroidSceneSpec(
         "complete the FrodoBots task 1",
-        "FrodoBots/Task1/Scene.usd",
-        "Task1/Scene.usd",
+        ("FrodoBots/Task1/Scene.usd", "Task1/Scene.usd"),
     ),
-    602: _spec(
-        "DROID-FrodoBots-Task2",
-        602,
+    "DROID-FrodoBots-Task2": DroidSceneSpec(
         "complete the FrodoBots task 2",
-        "FrodoBots/Task2/Scene.usd",
-        "Task2/Scene.usd",
+        ("FrodoBots/Task2/Scene.usd", "Task2/Scene.usd"),
     ),
 }
-
-ENV_ID_TO_SCENE = {spec.env_id: spec for spec in DROID_SCENES.values()}
 
 
 def get_data_path() -> Path:
@@ -162,70 +109,12 @@ def resolve_scene_asset_path(scene_spec: DroidSceneSpec) -> Path:
     )
 
 
-def get_scene_spec(scene: int | str) -> DroidSceneSpec:
-    if isinstance(scene, str):
-        if scene.isdigit():
-            scene = int(scene)
-        elif scene in ENV_ID_TO_SCENE:
-            return ENV_ID_TO_SCENE[scene]
-        else:
-            valid = ", ".join(spec.env_id for spec in DROID_SCENES.values())
-            raise ValueError(f"Unknown DROID scene {scene!r}. Valid env ids: {valid}")
-
+def get_scene_spec(env_id: str) -> DroidSceneSpec:
     try:
-        return DROID_SCENES[int(scene)]
-    except (KeyError, ValueError) as exc:
-        valid = ", ".join(str(scene_id) for scene_id in DROID_SCENES)
-        raise ValueError(f"Unknown DROID scene {scene!r}. Valid scene ids: {valid}") from exc
-
-
-def _relative_scene_prim_path(stage: Usd.Stage, prim: Usd.Prim) -> str:
-    prim_path = str(prim.GetPath())
-    default_prim = stage.GetDefaultPrim()
-    root_candidates = []
-    if default_prim and default_prim.IsValid():
-        root_candidates.append(str(default_prim.GetPath()))
-    root_candidates.append("/World")
-
-    for root_path in root_candidates:
-        if prim_path == root_path:
-            return ""
-        if prim_path.startswith(f"{root_path}/"):
-            return prim_path[len(root_path):]
-
-    return prim_path
-
-
-def _scene_attr_name(relative_prim_path: str, used_names: set[str]) -> str:
-    name = relative_prim_path.strip("/").replace("/", "_") or "object"
-    name = "".join(char if char.isalnum() or char == "_" else "_" for char in name)
-    if name[0].isdigit():
-        name = f"object_{name}"
-
-    base_name = name
-    suffix = 2
-    while name in used_names:
-        name = f"{base_name}_{suffix}"
-        suffix += 1
-    used_names.add(name)
-    return name
-
-
-def _rigid_body_initial_state(prim: Usd.Prim) -> RigidObjectCfg.InitialStateCfg:
-    pos_attr = prim.GetAttribute("xformOp:translate")
-    rot_attr = prim.GetAttribute("xformOp:orient")
-    pos = pos_attr.Get() if pos_attr and pos_attr.HasAuthoredValueOpinion() else (0.0, 0.0, 0.0)
-    rot_value = rot_attr.Get() if rot_attr and rot_attr.HasAuthoredValueOpinion() else None
-    if rot_value is None:
-        rot = (1.0, 0.0, 0.0, 0.0)
-    else:
-        rot = (
-            rot_value.GetReal(),
-            rot_value.GetImaginary()[0],
-            rot_value.GetImaginary()[1],
-            rot_value.GetImaginary()[2],
-        )
-    return RigidObjectCfg.InitialStateCfg(pos=pos, rot=rot)
+        return DROID_SCENES[env_id]
+    except KeyError as exc:
+        valid = ", ".join(DROID_SCENES)
+        raise ValueError(f"Unknown DROID environment {env_id!r}. Valid env ids: {valid}") from exc
 
 
 @configclass
@@ -288,8 +177,8 @@ class SceneCfg(InteractiveSceneCfg):
         ),
     )
 
-    def dynamic_scene(self, scene_name: int | str) -> dict:
-        scene_spec = get_scene_spec(scene_name)
+    def dynamic_scene(self, env_id: str) -> dict:
+        scene_spec = get_scene_spec(env_id)
         environment_path = resolve_scene_asset_path(scene_spec)
 
         scene = AssetBaseCfg(
@@ -299,51 +188,11 @@ class SceneCfg(InteractiveSceneCfg):
                     ),
                 )
         self.scene = scene
-        scene_object_names = []
-        scene_objects = {}
-
-        if scene_spec.scene_id > 3:
-            return {
-                "scene_id": scene_spec.scene_id,
-                "scene_env_id": scene_spec.env_id,
-                "scene_instruction": scene_spec.instruction,
-                "scene_asset_path": str(environment_path),
-                "scene_object_names": scene_object_names,
-                "scene_objects": scene_objects,
-            }
-
-        stage = Usd.Stage.Open(
-            str(environment_path)
-        )
-        if stage is None:
-            raise RuntimeError(f"Failed to open DROID scene asset: {environment_path}")
-
-        used_object_names = set()
-        for child in stage.Traverse():
-            if not UsdPhysics.RigidBodyAPI(child):
-                continue
-
-            relative_prim_path = _relative_scene_prim_path(stage, child)
-            if not relative_prim_path:
-                continue
-
-            name = _scene_attr_name(relative_prim_path, used_object_names)
-            scene_object_names.append(name)
-            asset = RigidObjectCfg(
-                        prim_path=f"{{ENV_REGEX_NS}}/scene{relative_prim_path}",
-                        spawn=None,
-                        init_state=_rigid_body_initial_state(child),
-                    )
-            setattr(self, name, asset)
-            scene_objects[name] = asset
 
         return {
-            "scene_id": scene_spec.scene_id,
-            "scene_env_id": scene_spec.env_id,
+            "scene_env_id": env_id,
             "scene_instruction": scene_spec.instruction,
             "scene_asset_path": str(environment_path),
-            "scene_object_names": scene_object_names,
-            "scene_objects": scene_objects,
         }
 
 
@@ -529,50 +378,9 @@ class EnvCfg(ManagerBasedRLEnvCfg):
         self.rerender_on_reset = True
 
     
-    def set_scene(self, scene_name: int | str):
-        scene_spec = get_scene_spec(scene_name)
-        self.scene_id = scene_spec.scene_id
-        self.scene_env_id = scene_spec.env_id
+    def set_scene(self, env_id: str):
+        scene_spec = get_scene_spec(env_id)
+        self.scene_env_id = env_id
         self.language_instruction = scene_spec.instruction
-        scene_metadata = self.scene.dynamic_scene(scene_spec.scene_id)
+        scene_metadata = self.scene.dynamic_scene(env_id)
         self.scene_asset_path = scene_metadata["scene_asset_path"]
-        self.scene_object_names = scene_metadata["scene_object_names"]
-        self.scene_objects = scene_metadata["scene_objects"]
-
-
-@configclass
-class CubeInBowlEnvCfg(EnvCfg):
-    def __post_init__(self):
-        super().__post_init__()
-        self.set_scene(1)
-
-
-@configclass
-class CanInMugEnvCfg(EnvCfg):
-    def __post_init__(self):
-        super().__post_init__()
-        self.set_scene(2)
-
-
-@configclass
-class BananaInBinEnvCfg(EnvCfg):
-    def __post_init__(self):
-        super().__post_init__()
-        self.set_scene(3)
-
-
-def make_env_cfg_class(scene_name: int | str) -> type[EnvCfg]:
-    scene_spec = get_scene_spec(scene_name)
-
-    @configclass
-    class DroidSceneEnvCfg(EnvCfg):
-        def __post_init__(self):
-            super().__post_init__()
-            self.set_scene(scene_spec.env_id)
-
-    class_name = f"{scene_spec.env_id.replace('-', '')}EnvCfg"
-    DroidSceneEnvCfg.__name__ = class_name
-    DroidSceneEnvCfg.__qualname__ = class_name
-    return DroidSceneEnvCfg
-
-


### PR DESCRIPTION
## Summary
- register each DROID sim scene as its own Gym environment
- centralize scene id/env id/prompt metadata
- allow `run_eval.py --environment <env_id>` while preserving the existing `--scene` path