### PR TITLE
Add Cybernetics DreamZero DROID evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ authentication, and run:
 python run_eval.py --backend cybernetics --episodes 10 --scene 1 --headless
 ```
 
+On a multi-GPU evaluator, select the Isaac physics device explicitly. This is
+useful when another policy server already owns the default GPU:
+
+```bash
+python run_eval.py --backend cybernetics --episodes 10 --scene 1 --headless --device cuda:1
+```
+
 No credential is accepted as a command-line argument. The integration assumes
 `ServiceClient.create_sampling_client(base_model="dreamzero-droid")` returns a
 sampling client with the typed DROID helper:

--- a/README.md
+++ b/README.md
@@ -63,6 +63,44 @@ Finally, run the evaluation script:
 python run_eval.py --episodes [INT] --scene [INT] --headless
 ```
 
+Each run writes one result object per episode to both `episodes.jsonl` and
+`episodes.json` alongside the episode videos under `runs/`. Results include the
+selected backend, termination state, inference latency summary, and structured
+errors. The upstream environments define only a 30-second timeout, not a task
+success term. Results therefore leave `success` unset and record the start/end
+object-to-target center distance as a diagnostic rather than inventing a pass
+threshold.
+
+### DreamZero-DROID through Cybernetics
+
+Install the Cybernetics SDK, configure its normal environment-based
+authentication, and run:
+
+```bash
+python run_eval.py --backend cybernetics --episodes 10 --scene 1 --headless
+```
+
+No credential is accepted as a command-line argument. The integration assumes
+`ServiceClient.create_sampling_client(base_model="dreamzero-droid")` returns a
+sampling client with the typed DROID helper:
+
+```python
+observation = cybernetics.DroidObservation.from_numpy(...)
+future = sampler.sample_droid(observation)
+response = future.result(timeout=2400)
+```
+
+The observation carries both exterior cameras, the wrist camera, seven arm
+joint positions, one gripper position, and the natural-language instruction.
+The response exposes a robot-space `action_chunk` with shape `[1, N, 8]`; the
+evaluation follows DreamZero's eight-action open-loop cadence. Each episode gets
+a fresh sampling session and the previous session is cancelled so backend frame
+history and causal cache ownership are released.
+
+The `flatdict` build override in `pyproject.toml` pins its isolated build to a
+setuptools release that still provides the undeclared `pkg_resources` module
+required by IsaacLab's dependency.
+
 ## Minimal Example
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ override-dependencies = [
   "websockets>=16.0"
 ]
 
+[tool.uv.extra-build-dependencies]
+# flatdict imports pkg_resources while building but does not declare setuptools.
+flatdict = ["setuptools<81"]
+
 [tool.uv.sources]
 torch = [
   { index = "pytorch-cu118", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },

--- a/run_eval.py
+++ b/run_eval.py
@@ -1,44 +1,147 @@
-"""
-Example script for running 10 rollouts of a DROID policy on the example environment.
+"""Run DROID simulation rollouts with OpenPI or Cybernetics inference.
 
-Usage:
+Examples:
 
-First, make sure you download the simulation assets and unpack them into the root directory of this package.
-
-Then, in a separate terminal, launch the policy server on localhost:8000 
--- make sure to set XLA_PYTHON_CLIENT_MEM_FRACTION to avoid JAX hogging all the GPU memory.
-
-For example, to launch a pi0-FAST-DROID policy (with joint position control), 
-run the command below in a separate terminal from the openpi "karl/droid_policies" branch:
-
-XLA_PYTHON_CLIENT_MEM_FRACTION=0.5 uv run scripts/serve_policy.py policy:checkpoint --policy.config=pi0_fast_droid_jointpos --policy.dir=s3://openpi-assets-simeval/pi0_fast_droid_jointpos
-
-Finally, run the evaluation script:
-
-python run_eval.py --episodes 10 --headless
+    python run_eval.py --episodes 10 --headless
+    python run_eval.py --backend cybernetics --episodes 10 --headless
 """
 
-import tyro
+from __future__ import annotations
+
 import argparse
-import gymnasium as gym
-import torch
-import cv2
-import mediapy
+import json
 from datetime import datetime
 from pathlib import Path
+from time import perf_counter
+from typing import Any, Literal
+
+import cv2
+import gymnasium as gym
+import mediapy
+import torch
+import tyro
 from tqdm import tqdm
 
-from sim_evals.inference.droid_jointpos import Client as DroidJointPosClient
+from sim_evals.episode_results import EpisodeResultWriter
+from sim_evals.inference.abstract_client import InferenceClient
+
+Backend = Literal["openpi", "cybernetics"]
+
+
+def _instruction_for_scene(scene: int) -> str:
+    instructions = {
+        1: "put the cube in the bowl",
+        2: "put the can in the mug",
+        3: "put banana in the bin",
+    }
+    try:
+        return instructions[scene]
+    except KeyError as exc:
+        raise ValueError(f"Scene {scene} not supported") from exc
+
+
+def _create_client(
+    backend: Backend,
+    *,
+    remote_host: str,
+    remote_port: int,
+    open_loop_horizon: int,
+    cybernetics_base_model: str,
+    cybernetics_model_path: str | None,
+    cybernetics_request_timeout: float,
+    cybernetics_session_timeout: float,
+) -> InferenceClient:
+    if backend == "openpi":
+        from sim_evals.inference.droid_jointpos import Client
+
+        return Client(
+            remote_host=remote_host,
+            remote_port=remote_port,
+            open_loop_horizon=open_loop_horizon,
+        )
+
+    from sim_evals.inference.cybernetics_dreamzero import Client
+
+    return Client(
+        base_model=cybernetics_base_model,
+        model_path=cybernetics_model_path,
+        request_timeout=cybernetics_request_timeout,
+        session_timeout=cybernetics_session_timeout,
+        open_loop_horizon=open_loop_horizon,
+    )
+
+
+def _bool_flag(value: Any) -> bool:
+    if hasattr(value, "item"):
+        value = value.item()
+    return bool(value)
+
+
+def _error(phase: str, exc: Exception) -> dict[str, str]:
+    return {"phase": phase, "type": type(exc).__name__, "message": str(exc)}
+
+
+def _task_distance(env: Any, scene: int) -> dict[str, Any]:
+    entities = {
+        1: ("rubiks_cube", "_24_bowl"),
+        2: ("_10_potted_meat_can", "_25_mug"),
+        3: ("_11_banana", "Magenta_Box"),
+    }
+    object_name, target_name = entities[scene]
+    try:
+        object_position = (
+            env.unwrapped.scene[object_name]
+            .data.root_pos_w[0, :3]
+            .detach()
+            .cpu()
+            .float()
+        )
+        target_position = (
+            env.unwrapped.scene[target_name]
+            .data.root_pos_w[0, :3]
+            .detach()
+            .cpu()
+            .float()
+        )
+        return {
+            "object_entity": object_name,
+            "target_entity": target_name,
+            "object_position_m": object_position.tolist(),
+            "target_position_m": target_position.tolist(),
+            "center_distance_m": float(
+                torch.linalg.vector_norm(object_position - target_position)
+            ),
+        }
+    except Exception as exc:
+        return {
+            "object_entity": object_name,
+            "target_entity": target_name,
+            "unavailable": _error("task_distance", exc),
+        }
 
 
 def main(
-        episodes:int = 10,
-        headless: bool = True,
-        scene: int = 1,
-        ):
-    # launch omniverse app with arguments (inside function to prevent overriding tyro)
+    episodes: int = 10,
+    headless: bool = True,
+    scene: int = 1,
+    backend: Backend = "openpi",
+    results_dir: Path | None = None,
+    remote_host: str = "localhost",
+    remote_port: int = 8000,
+    open_loop_horizon: int = 8,
+    cybernetics_base_model: str = "dreamzero-droid",
+    cybernetics_model_path: str | None = None,
+    cybernetics_request_timeout: float = 2400.0,
+    cybernetics_session_timeout: float = 2400.0,
+) -> None:
+    """Run DROID episodes and write ``episodes.jsonl`` plus ``episodes.json``."""
+    if episodes < 1:
+        raise ValueError("episodes must be at least 1")
+
+    # Launch Omniverse before importing any IsaacLab-dependent modules.
     from isaaclab.app import AppLauncher
-    parser = argparse.ArgumentParser(description="Tutorial on creating an empty stage.")
+
+    parser = argparse.ArgumentParser(description="Run DROID policy evaluation")
     AppLauncher.add_app_launcher_args(parser)
     args_cli, _ = parser.parse_known_args()
     args_cli.enable_cameras = True
@@ -46,65 +149,137 @@ def main(
     app_launcher = AppLauncher(args_cli)
     simulation_app = app_launcher.app
 
-    # All IsaacLab dependent modules should be imported after the app is launched
-    import sim_evals.environments # noqa: F401
+    import sim_evals.environments  # noqa: F401
     from isaaclab_tasks.utils import parse_env_cfg
 
-
-    # Initialize the env
     env_cfg = parse_env_cfg(
         "DROID",
         device=args_cli.device,
         num_envs=1,
         use_fabric=True,
     )
-    instruction = None
-    match scene:
-        case 1:
-            instruction = "put the cube in the bowl"
-        case 2:
-            instruction = "put the can in the mug"
-        case 3:
-            instruction = "put banana in the bin"
-        case _:
-            raise ValueError(f"Scene {scene} not supported")
-        
+    instruction = _instruction_for_scene(scene)
     env_cfg.set_scene(scene)
     env = gym.make("DROID", cfg=env_cfg)
 
     obs, _ = env.reset()
-    obs, _ = env.reset() # need second render cycle to get correctly loaded materials
-    client = DroidJointPosClient()
+    obs, _ = env.reset()  # A second render cycle loads scene materials correctly.
+    client = _create_client(
+        backend,
+        remote_host=remote_host,
+        remote_port=remote_port,
+        open_loop_horizon=open_loop_horizon,
+        cybernetics_base_model=cybernetics_base_model,
+        cybernetics_model_path=cybernetics_model_path,
+        cybernetics_request_timeout=cybernetics_request_timeout,
+        cybernetics_session_timeout=cybernetics_session_timeout,
+    )
 
-
-    video_dir = Path("runs") / datetime.now().strftime("%Y-%m-%d") / datetime.now().strftime("%H-%M-%S")
-    video_dir.mkdir(parents=True, exist_ok=True)
-    video = []
-    ep = 0
+    now = datetime.now()
+    run_dir = results_dir or Path("runs") / now.strftime("%Y-%m-%d") / now.strftime(
+        "%H-%M-%S"
+    )
+    result_writer = EpisodeResultWriter(run_dir)
     max_steps = env.env.max_episode_length
-    with torch.no_grad():
-        for ep in range(episodes):
-            for _ in tqdm(range(max_steps), desc=f"Episode {ep+1}/{episodes}"):
-                ret = client.infer(obs, instruction)
+
+    try:
+        with torch.no_grad():
+            for episode_index in range(episodes):
+                episode_started = perf_counter()
+                video: list[Any] = []
+                errors: list[dict[str, str]] = []
+                terminated = False
+                truncated = False
+                steps = 0
+
+                try:
+                    obs, _ = env.reset()
+                except Exception as exc:
+                    errors.append(_error("environment_reset", exc))
+                initial_task_distance = _task_distance(env, scene)
+
+                try:
+                    client.reset()
+                except Exception as exc:
+                    errors.append(_error("session_reset", exc))
+
+                if not errors:
+                    for _ in tqdm(
+                        range(max_steps), desc=f"Episode {episode_index + 1}/{episodes}"
+                    ):
+                        try:
+                            inference = client.infer(obs, instruction)
+                        except Exception as exc:
+                            errors.append(_error("inference", exc))
+                            break
+
+                        if not headless:
+                            cv2.imshow(
+                                "DROID Cameras",
+                                cv2.cvtColor(inference["viz"], cv2.COLOR_RGB2BGR),
+                            )
+                            cv2.waitKey(1)
+                        video.append(inference["viz"])
+
+                        try:
+                            action = torch.as_tensor(inference["action"])[None]
+                            obs, _, term, trunc, _ = env.step(action)
+                        except Exception as exc:
+                            errors.append(_error("environment_step", exc))
+                            break
+
+                        steps += 1
+                        terminated = _bool_flag(term)
+                        truncated = _bool_flag(trunc)
+                        if terminated or truncated:
+                            break
+
+                video_path: str | None = None
+                if video:
+                    episode_video_path = run_dir / f"episode_{episode_index}.mp4"
+                    try:
+                        mediapy.write_video(episode_video_path, video, fps=15)
+                        video_path = str(episode_video_path)
+                    except Exception as exc:
+                        errors.append(_error("video_write", exc))
+
+                result = {
+                    "episode": episode_index + 1,
+                    "backend": backend,
+                    "scene": scene,
+                    "instruction": instruction,
+                    "status": "error" if errors else "completed",
+                    "steps": steps,
+                    "max_steps": max_steps,
+                    "terminated": terminated,
+                    "truncated": truncated,
+                    "duration_ms": (perf_counter() - episode_started) * 1000,
+                    "video_path": video_path,
+                    "errors": errors,
+                    "inference": client.episode_metrics(),
+                    "task_diagnostic": {
+                        "protocol": "unscored_upstream_center_distance",
+                        "success": None,
+                        "initial": initial_task_distance,
+                        "final": _task_distance(env, scene),
+                    },
+                }
+                result_writer.record(result)
+                tqdm.write(json.dumps(result, sort_keys=True))
+    finally:
+        try:
+            client.close()
+        finally:
+            try:
+                env.close()
+            finally:
                 if not headless:
-                    cv2.imshow("Right Camera", cv2.cvtColor(ret["viz"], cv2.COLOR_RGB2BGR))
-                    cv2.waitKey(1)
-                video.append(ret["viz"])
-                action = torch.tensor(ret["action"])[None]
-                obs, _, term, trunc, _ = env.step(action)
-                if term or trunc:
-                    break
+                    cv2.destroyAllWindows()
+                simulation_app.close()
 
-            client.reset()
-            mediapy.write_video(
-                video_dir / f"episode_{ep}.mp4",
-                video,
-                fps=15,
-            )
-            video = []
+    print(f"Episode JSONL: {result_writer.jsonl_path}")
+    print(f"Episode JSON: {result_writer.json_path}")
 
-    env.close()
-    simulation_app.close()
 
 if __name__ == "__main__":
-    args = tyro.cli(main)
+    tyro.cli(main)

--- a/run_eval.py
+++ b/run_eval.py
@@ -133,6 +133,7 @@ def main(
     cybernetics_model_path: str | None = None,
     cybernetics_request_timeout: float = 2400.0,
     cybernetics_session_timeout: float = 2400.0,
+    device: str = "cuda:0",
 ) -> None:
     """Run DROID episodes and write ``episodes.jsonl`` plus ``episodes.json``."""
     if episodes < 1:
@@ -146,9 +147,12 @@ def main(
     args_cli, _ = parser.parse_known_args()
     args_cli.enable_cameras = True
     args_cli.headless = headless
+    args_cli.device = device
+    print(f"Launching Isaac Sim on {device}", flush=True)
     app_launcher = AppLauncher(args_cli)
     simulation_app = app_launcher.app
 
+    print("Loading DROID environment", flush=True)
     import sim_evals.environments  # noqa: F401
     from isaaclab_tasks.utils import parse_env_cfg
 
@@ -162,8 +166,10 @@ def main(
     env_cfg.set_scene(scene)
     env = gym.make("DROID", cfg=env_cfg)
 
+    print("Rendering initial DROID observations", flush=True)
     obs, _ = env.reset()
     obs, _ = env.reset()  # A second render cycle loads scene materials correctly.
+    print(f"Creating {backend} inference client", flush=True)
     client = _create_client(
         backend,
         remote_host=remote_host,
@@ -181,6 +187,7 @@ def main(
     )
     result_writer = EpisodeResultWriter(run_dir)
     max_steps = env.env.max_episode_length
+    print(f"Starting {episodes} evaluation episode(s)", flush=True)
 
     try:
         with torch.no_grad():

--- a/src/sim_evals/episode_results.py
+++ b/src/sim_evals/episode_results.py
@@ -1,0 +1,30 @@
+"""Durable JSONL and JSON episode result output."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+class EpisodeResultWriter:
+    def __init__(self, run_dir: Path) -> None:
+        self.run_dir = run_dir
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+        self.jsonl_path = self.run_dir / "episodes.jsonl"
+        self.json_path = self.run_dir / "episodes.json"
+        self._results: list[dict[str, Any]] = []
+        self.jsonl_path.write_text("")
+        self._write_json()
+
+    def record(self, result: Mapping[str, Any]) -> None:
+        serialized = dict(result)
+        self._results.append(serialized)
+        with self.jsonl_path.open("a") as output:
+            output.write(json.dumps(serialized, sort_keys=True) + "\n")
+        self._write_json()
+
+    def _write_json(self) -> None:
+        self.json_path.write_text(
+            json.dumps(self._results, indent=2, sort_keys=True) + "\n"
+        )

--- a/src/sim_evals/inference/abstract_client.py
+++ b/src/sim_evals/inference/abstract_client.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class InferenceClient(ABC):
@@ -25,3 +26,9 @@ class InferenceClient(ABC):
         """
         pass
 
+    def episode_metrics(self) -> dict[str, Any]:
+        """Return JSON-serializable metrics for the current episode."""
+        return {}
+
+    def close(self) -> None:
+        """Release client-owned resources."""

--- a/src/sim_evals/inference/cybernetics_dreamzero.py
+++ b/src/sim_evals/inference/cybernetics_dreamzero.py
@@ -1,0 +1,223 @@
+"""Cybernetics DreamZero-DROID inference client."""
+
+from __future__ import annotations
+
+from time import perf_counter
+from typing import Any, Mapping, Protocol
+
+import numpy as np
+
+from .abstract_client import InferenceClient
+from .droid_observation import DroidObservation, camera_strip
+
+
+class DroidObservationSamplingAPI(Protocol):
+    """Narrow API expected from a typed/raw Cybernetics DROID sampler."""
+
+    def sample_droid(
+        self, observation: DroidObservation, *, timeout: float | None = None
+    ) -> Any: ...
+
+    def reset_sampling_session(self) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class CyberneticsSDKDroidSamplingAPI:
+    """Lazy bridge to the typed Cybernetics SDK sampling surface."""
+
+    def __init__(
+        self,
+        *,
+        base_model: str = "dreamzero-droid",
+        model_path: str | None = None,
+        session_timeout: float = 2400.0,
+    ) -> None:
+        try:
+            from cybernetics import DroidObservation as SDKDroidObservation
+            from cybernetics import ServiceClient
+        except ImportError as exc:
+            raise RuntimeError(
+                "The Cybernetics backend requires the 'cybernetic-physics' SDK"
+            ) from exc
+
+        self._service_client_type = ServiceClient
+        self._sdk_observation_type = SDKDroidObservation
+        self._service_client: Any | None = None
+        self._base_model = base_model
+        self._model_path = model_path
+        self._session_timeout = session_timeout
+        self._sampling_client: Any | None = None
+
+    def reset_sampling_session(self) -> None:
+        self._close_active_session()
+        self._service_client = self._service_client_type()
+        create_kwargs: dict[str, Any] = {"timeout": self._session_timeout}
+        if self._model_path is not None:
+            create_kwargs["model_path"] = self._model_path
+        else:
+            create_kwargs["base_model"] = self._base_model
+        self._sampling_client = self._service_client.create_sampling_client(
+            **create_kwargs
+        )
+
+    def sample_droid(
+        self, observation: DroidObservation, *, timeout: float | None = None
+    ) -> Any:
+        if self._sampling_client is None:
+            self.reset_sampling_session()
+        sample = getattr(self._sampling_client, "sample_droid", None)
+        if not callable(sample):
+            raise RuntimeError(
+                "Cybernetics SamplingClient must expose sample_droid(observation)"
+            )
+        sdk_observation = self._sdk_observation_type.from_numpy(
+            exterior_image_0_left=observation.exterior_image_1_left,
+            exterior_image_1_left=observation.exterior_image_2_left,
+            wrist_image_left=observation.wrist_image_left,
+            joint_position=observation.joint_position,
+            gripper_position=observation.gripper_position,
+            instruction=observation.instruction,
+        )
+        result = sample(sdk_observation)
+        if hasattr(result, "result"):
+            return result.result(timeout=timeout)
+        return result
+
+    def _close_active_session(self) -> None:
+        service_client = self._service_client
+        self._sampling_client = None
+        self._service_client = None
+        if service_client is None:
+            return
+        try:
+            rest_client = service_client.create_rest_client()
+            rest_client.cancel_session(service_client.session_id).result(
+                timeout=self._session_timeout
+            )
+        finally:
+            service_client.holder.close()
+
+    def close(self) -> None:
+        self._close_active_session()
+
+
+def _action_chunk(response: Any) -> np.ndarray:
+    if isinstance(response, Mapping):
+        value = response.get("action_chunk")
+    else:
+        value = getattr(response, "action_chunk", None)
+    if value is None:
+        raise ValueError("Cybernetics response did not include action_chunk")
+    if hasattr(value, "to_numpy"):
+        value = value.to_numpy()
+    elif isinstance(value, Mapping) and "data" in value:
+        shape = value.get("shape")
+        value = np.asarray(value["data"])
+        if shape is not None:
+            value = value.reshape(shape)
+    chunk = np.asarray(value, dtype=np.float32)
+    if chunk.ndim == 3 and chunk.shape[0] == 1:
+        chunk = chunk[0]
+    if chunk.ndim != 2 or chunk.shape[0] < 1 or chunk.shape[1] != 8:
+        raise ValueError(
+            f"DreamZero-DROID action_chunk must have shape [N,8], got {chunk.shape}"
+        )
+    if not np.isfinite(chunk).all():
+        raise ValueError("DreamZero-DROID action_chunk must contain only finite values")
+    return np.ascontiguousarray(chunk)
+
+
+class Client(InferenceClient):
+    """Consume validated DreamZero-DROID joint-position action chunks."""
+
+    def __init__(
+        self,
+        *,
+        sampling_api: DroidObservationSamplingAPI | None = None,
+        base_model: str = "dreamzero-droid",
+        model_path: str | None = None,
+        request_timeout: float = 2400.0,
+        session_timeout: float = 2400.0,
+        open_loop_horizon: int = 8,
+    ) -> None:
+        self.sampling_api = sampling_api or CyberneticsSDKDroidSamplingAPI(
+            base_model=base_model,
+            model_path=model_path,
+            session_timeout=session_timeout,
+        )
+        self.request_timeout = request_timeout
+        if open_loop_horizon < 1:
+            raise ValueError("open_loop_horizon must be at least 1")
+        self.open_loop_horizon = open_loop_horizon
+        self._action_chunk: np.ndarray | None = None
+        self._action_index = 0
+        self._sample_latencies_ms: list[float] = []
+        self._errors: list[dict[str, str]] = []
+        self._reset_latency_ms: float | None = None
+
+    def reset(self) -> None:
+        self._action_chunk = None
+        self._action_index = 0
+        self._sample_latencies_ms = []
+        self._errors = []
+        started = perf_counter()
+        try:
+            self.sampling_api.reset_sampling_session()
+        except Exception as exc:
+            self._errors.append(
+                {"phase": "reset", "type": type(exc).__name__, "message": str(exc)}
+            )
+            raise
+        finally:
+            self._reset_latency_ms = (perf_counter() - started) * 1000
+
+    def infer(self, obs: Mapping[str, Any], instruction: str) -> dict[str, Any]:
+        observation = DroidObservation.from_sim_observation(obs, instruction)
+        sampled_new_chunk = False
+        latency_ms: float | None = None
+        if self._action_chunk is None or self._action_index >= len(self._action_chunk):
+            sampled_new_chunk = True
+            started = perf_counter()
+            try:
+                response = self.sampling_api.sample_droid(
+                    observation, timeout=self.request_timeout
+                )
+                self._action_chunk = _action_chunk(response)[: self.open_loop_horizon]
+                self._action_index = 0
+            except Exception as exc:
+                self._errors.append(
+                    {"phase": "sample", "type": type(exc).__name__, "message": str(exc)}
+                )
+                raise
+            finally:
+                latency_ms = (perf_counter() - started) * 1000
+                self._sample_latencies_ms.append(latency_ms)
+
+        assert self._action_chunk is not None
+        action = self._action_chunk[self._action_index].copy()
+        self._action_index += 1
+        return {
+            "action": action,
+            "viz": camera_strip(observation),
+            "sampled_new_chunk": sampled_new_chunk,
+            "latency_ms": latency_ms,
+        }
+
+    def episode_metrics(self) -> dict[str, Any]:
+        latency = self._sample_latencies_ms
+        return {
+            "sampling_requests": len(latency),
+            "sampling_errors": list(self._errors),
+            "sampling_latency_ms": {
+                "count": len(latency),
+                "min": min(latency) if latency else None,
+                "max": max(latency) if latency else None,
+                "mean": sum(latency) / len(latency) if latency else None,
+                "total": sum(latency),
+            },
+            "session_reset_latency_ms": self._reset_latency_ms,
+        }
+
+    def close(self) -> None:
+        self.sampling_api.close()

--- a/src/sim_evals/inference/droid_observation.py
+++ b/src/sim_evals/inference/droid_observation.py
@@ -1,0 +1,92 @@
+"""Import-light DROID observation extraction and validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import numpy as np
+
+
+def _to_numpy(value: Any) -> np.ndarray:
+    if isinstance(value, np.ndarray):
+        return value
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    if hasattr(value, "numpy"):
+        return np.asarray(value.numpy())
+    return np.asarray(value)
+
+
+def _camera(value: Any, name: str) -> np.ndarray:
+    image = _to_numpy(value)
+    if image.ndim == 4 and image.shape[0] == 1:
+        image = image[0]
+    if image.ndim != 3 or image.shape[-1] != 3:
+        raise ValueError(f"{name} must be an RGB image [H,W,3], got {image.shape}")
+    if image.dtype != np.uint8:
+        if image.dtype.kind not in {"i", "u"} or image.size == 0:
+            raise ValueError(f"{name} must contain uint8-compatible RGB values")
+        if image.min() < 0 or image.max() > 255:
+            raise ValueError(f"{name} RGB values must be in [0, 255]")
+        image = image.astype(np.uint8)
+    return np.ascontiguousarray(image)
+
+
+def _vector(value: Any, size: int, name: str) -> np.ndarray:
+    vector = _to_numpy(value).astype(np.float32, copy=False).reshape(-1)
+    if vector.shape != (size,):
+        raise ValueError(f"{name} must contain {size} values, got {vector.shape}")
+    if not np.isfinite(vector).all():
+        raise ValueError(f"{name} must contain only finite values")
+    return np.ascontiguousarray(vector)
+
+
+@dataclass(frozen=True)
+class DroidObservation:
+    """One raw DROID policy observation with the simulator batch removed."""
+
+    exterior_image_1_left: np.ndarray
+    exterior_image_2_left: np.ndarray
+    wrist_image_left: np.ndarray
+    joint_position: np.ndarray
+    gripper_position: np.ndarray
+    instruction: str
+
+    @classmethod
+    def from_sim_observation(
+        cls, observation: Mapping[str, Any], instruction: str
+    ) -> "DroidObservation":
+        if not instruction.strip():
+            raise ValueError("instruction must not be empty")
+        policy = observation.get("policy")
+        if not isinstance(policy, Mapping):
+            raise ValueError("observation must contain a 'policy' mapping")
+        return cls(
+            exterior_image_1_left=_camera(policy["external_cam"], "external_cam"),
+            exterior_image_2_left=_camera(policy["external_cam_2"], "external_cam_2"),
+            wrist_image_left=_camera(policy["wrist_cam"], "wrist_cam"),
+            joint_position=_vector(policy["arm_joint_pos"], 7, "arm_joint_pos"),
+            gripper_position=_vector(policy["gripper_pos"], 1, "gripper_pos"),
+            instruction=instruction,
+        )
+
+
+def camera_strip(observation: DroidObservation, size: int = 224) -> np.ndarray:
+    """Build a compact three-camera visualization without OpenCV or Isaac Sim."""
+
+    def resize_nearest(image: np.ndarray) -> np.ndarray:
+        rows = np.linspace(0, image.shape[0] - 1, size, dtype=np.int64)
+        columns = np.linspace(0, image.shape[1] - 1, size, dtype=np.int64)
+        return image[rows[:, None], columns]
+
+    return np.concatenate(
+        [
+            resize_nearest(observation.exterior_image_1_left),
+            resize_nearest(observation.exterior_image_2_left),
+            resize_nearest(observation.wrist_image_left),
+        ],
+        axis=1,
+    )

--- a/tests/test_cybernetics_dreamzero.py
+++ b/tests/test_cybernetics_dreamzero.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import patch
+from typing import Any
+
+import numpy as np
+
+from sim_evals.episode_results import EpisodeResultWriter
+from sim_evals.inference.cybernetics_dreamzero import (
+    Client,
+    CyberneticsSDKDroidSamplingAPI,
+)
+from sim_evals.inference.droid_observation import DroidObservation
+
+
+def _observation() -> dict[str, Any]:
+    return {
+        "policy": {
+            "external_cam": np.full((1, 4, 6, 3), 11, dtype=np.uint8),
+            "external_cam_2": np.full((1, 4, 6, 3), 22, dtype=np.uint8),
+            "wrist_cam": np.full((1, 4, 6, 3), 33, dtype=np.uint8),
+            "arm_joint_pos": np.arange(7, dtype=np.float32),
+            "gripper_pos": np.array([0.25], dtype=np.float32),
+        }
+    }
+
+
+class FakeSamplingAPI:
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.requests: list[DroidObservation] = []
+        self.timeouts: list[float | None] = []
+        self.reset_calls = 0
+        self.closed = False
+
+    def sample_droid(
+        self, observation: DroidObservation, *, timeout: float | None = None
+    ) -> Any:
+        self.requests.append(observation)
+        self.timeouts.append(timeout)
+        response = self.responses[len(self.requests) - 1]
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def reset_sampling_session(self) -> None:
+        self.reset_calls += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class CyberneticsDreamZeroClientTest(unittest.TestCase):
+    def test_concrete_bridge_uses_typed_sdk_sample_and_cancels_session(self) -> None:
+        sampled: list[object] = []
+        cancelled: list[str] = []
+        closed: list[bool] = []
+
+        class SDKObservation:
+            @classmethod
+            def from_numpy(cls, **kwargs):
+                return kwargs
+
+        class Future:
+            def __init__(self, value):
+                self.value = value
+
+            def result(self, timeout=None):
+                return self.value
+
+        class Sampler:
+            def sample_droid(self, observation):
+                sampled.append(observation)
+                return Future({"action_chunk": np.zeros((1, 1, 8))})
+
+        class RestClient:
+            def cancel_session(self, session_id):
+                cancelled.append(session_id)
+                return Future({"ok": True})
+
+        class ServiceClient:
+            session_id = "session-1"
+            holder = SimpleNamespace(close=lambda: closed.append(True))
+
+            def create_sampling_client(self, **_kwargs):
+                return Sampler()
+
+            def create_rest_client(self):
+                return RestClient()
+
+        fake_sdk = SimpleNamespace(
+            DroidObservation=SDKObservation,
+            ServiceClient=ServiceClient,
+        )
+        observation = DroidObservation.from_sim_observation(
+            _observation(), "put the cube in the bowl"
+        )
+        with patch.dict("sys.modules", {"cybernetics": fake_sdk}):
+            api = CyberneticsSDKDroidSamplingAPI()
+            api.reset_sampling_session()
+            response = api.sample_droid(observation, timeout=19)
+            api.close()
+
+        self.assertEqual(response["action_chunk"].shape, (1, 1, 8))
+        self.assertEqual(sampled[0]["instruction"], "put the cube in the bowl")
+        self.assertEqual(cancelled, ["session-1"])
+        self.assertEqual(closed, [True])
+
+    def test_collects_raw_droid_observation_and_consumes_action_chunk(self) -> None:
+        action_chunk = np.arange(16, dtype=np.float32).reshape(1, 2, 8)
+        api = FakeSamplingAPI([{"action_chunk": action_chunk}])
+        client = Client(sampling_api=api, request_timeout=19.0)
+
+        client.reset()
+        first = client.infer(_observation(), "put the cube in the bowl")
+        second = client.infer(_observation(), "put the cube in the bowl")
+
+        self.assertEqual(api.reset_calls, 1)
+        self.assertEqual(len(api.requests), 1)
+        self.assertEqual(api.timeouts, [19.0])
+        request = api.requests[0]
+        np.testing.assert_array_equal(request.exterior_image_1_left, 11)
+        np.testing.assert_array_equal(request.exterior_image_2_left, 22)
+        np.testing.assert_array_equal(request.wrist_image_left, 33)
+        np.testing.assert_array_equal(request.joint_position, np.arange(7))
+        np.testing.assert_array_equal(request.gripper_position, [0.25])
+        self.assertEqual(request.instruction, "put the cube in the bowl")
+        np.testing.assert_array_equal(first["action"], action_chunk[0, 0])
+        np.testing.assert_array_equal(second["action"], action_chunk[0, 1])
+        self.assertTrue(first["sampled_new_chunk"])
+        self.assertFalse(second["sampled_new_chunk"])
+        self.assertEqual(first["viz"].shape, (224, 3 * 224, 3))
+        self.assertEqual(client.episode_metrics()["sampling_requests"], 1)
+
+    def test_accepts_typed_and_raw_tensor_action_chunks(self) -> None:
+        class TypedTensor:
+            def to_numpy(self) -> np.ndarray:
+                return np.ones((1, 1, 8), dtype=np.float32)
+
+        class TypedResponse:
+            action_chunk = TypedTensor()
+
+        responses = [
+            TypedResponse(),
+            {"action_chunk": {"data": list(range(8)), "shape": [1, 1, 8]}},
+        ]
+        api = FakeSamplingAPI(responses)
+        client = Client(sampling_api=api)
+        client.reset()
+
+        typed = client.infer(_observation(), "put the cube in the bowl")
+        raw = client.infer(_observation(), "put the cube in the bowl")
+
+        np.testing.assert_array_equal(typed["action"], np.ones(8))
+        np.testing.assert_array_equal(raw["action"], np.arange(8))
+
+    def test_rejects_non_joint_position_action_chunks(self) -> None:
+        api = FakeSamplingAPI([{"action_chunk": np.zeros((2, 7), dtype=np.float32)}])
+        client = Client(sampling_api=api)
+        client.reset()
+
+        with self.assertRaisesRegex(ValueError, r"\[N,8\]"):
+            client.infer(_observation(), "put the cube in the bowl")
+
+        metrics = client.episode_metrics()
+        self.assertEqual(metrics["sampling_requests"], 1)
+        self.assertEqual(metrics["sampling_errors"][0]["phase"], "sample")
+
+    def test_reports_sampling_errors_and_resets_each_episode(self) -> None:
+        api = FakeSamplingAPI([RuntimeError("backend unavailable")])
+        client = Client(sampling_api=api)
+        client.reset()
+
+        with self.assertRaisesRegex(RuntimeError, "backend unavailable"):
+            client.infer(_observation(), "put the cube in the bowl")
+
+        metrics = client.episode_metrics()
+        self.assertEqual(metrics["sampling_errors"][0]["type"], "RuntimeError")
+        self.assertGreaterEqual(metrics["sampling_latency_ms"]["total"], 0)
+        client.reset()
+        self.assertEqual(api.reset_calls, 2)
+        self.assertEqual(client.episode_metrics()["sampling_errors"], [])
+
+    def test_validates_seven_joint_positions_before_sampling(self) -> None:
+        observation = _observation()
+        observation["policy"]["arm_joint_pos"] = np.zeros(6, dtype=np.float32)
+        api = FakeSamplingAPI([])
+        client = Client(sampling_api=api)
+
+        with self.assertRaisesRegex(ValueError, "7 values"):
+            client.infer(observation, "put the cube in the bowl")
+        self.assertEqual(api.requests, [])
+
+    def test_close_delegates_to_sampling_api(self) -> None:
+        api = FakeSamplingAPI([])
+        client = Client(sampling_api=api)
+        client.close()
+        self.assertTrue(api.closed)
+
+
+class EpisodeResultWriterTest(unittest.TestCase):
+    def test_writes_matching_jsonl_and_json_results(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            writer = EpisodeResultWriter(Path(directory))
+            writer.record({"episode": 1, "status": "completed"})
+            writer.record({"episode": 2, "status": "error"})
+
+            lines = writer.jsonl_path.read_text().splitlines()
+            self.assertEqual(len(lines), 2)
+            self.assertIn('"episode": 1', lines[0])
+            self.assertIn('"episode": 2', writer.json_path.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Cybernetics SDK inference backend for DreamZero-DROID
- create a fresh sampling session per episode and release causal state between episodes
- persist episode JSONL/JSON, videos, latency, structured errors, and unscored center-distance diagnostics
- preserve the existing OpenPI default path
- work around IsaacLab flatdict isolated-build metadata with a scoped setuptools pin

## Validation
- `PYTHONPATH=src uv run --no-project --with numpy --python 3.11 python -m unittest discover -s tests -v`
- Ruff on touched Python files
- `uv lock`
- Freiza Isaac environment sync and full simulator run tracked separately because it requires GPU and the production DreamZero endpoint

The upstream DROID environments expose a timeout but no success termination, so this intentionally reports diagnostics without inventing a benchmark success threshold.